### PR TITLE
Reuse compatible iOS audio session in TTSKit playback

### DIFF
--- a/Sources/TTSKit/Qwen3TTS/Qwen3Config.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3Config.swift
@@ -235,6 +235,13 @@ open class TTSKitConfig {
     /// `nil` loads when `modelFolder` is non-nil, matching WhisperKit's default.
     public var load: Bool?
 
+    // MARK: - Playback
+
+    /// Preserve the host app's existing iOS audio session configuration during playback startup.
+    /// When `true`, `TTSKit` only activates the shared `AVAudioSession` instead of forcing
+    /// it to `.playback`.
+    public var preserveExistingAudioSession: Bool
+
     // MARK: - Generation
 
     /// Optional seed for reproducible generation.
@@ -283,6 +290,7 @@ open class TTSKitConfig {
         download: Bool = true,
         prewarm: Bool? = nil,
         load: Bool? = nil,
+        preserveExistingAudioSession: Bool = false,
         seed: UInt64? = nil
     ) {
         self.model = model
@@ -308,6 +316,7 @@ open class TTSKitConfig {
         self.download = download
         self.prewarm = prewarm
         self.load = load
+        self.preserveExistingAudioSession = preserveExistingAudioSession
         self.seed = seed
     }
 

--- a/Sources/TTSKit/Qwen3TTS/Qwen3Config.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3Config.swift
@@ -239,6 +239,13 @@ open class TTSKitConfig {
     /// `nil` loads when `modelFolder` is non-nil, matching WhisperKit's default.
     public var load: Bool?
 
+    // MARK: - Playback
+
+    /// Preserve the host app's existing iOS audio session configuration during playback startup.
+    /// When `true`, `TTSKit` only activates the shared `AVAudioSession` instead of forcing
+    /// it to `.playback`.
+    public var preserveExistingAudioSession: Bool
+
     // MARK: - Generation
 
     /// Optional seed for reproducible generation.
@@ -288,6 +295,7 @@ open class TTSKitConfig {
         download: Bool = true,
         prewarm: Bool? = nil,
         load: Bool? = nil,
+        preserveExistingAudioSession: Bool = false,
         seed: UInt64? = nil
     ) {
         self.model = model
@@ -314,6 +322,7 @@ open class TTSKitConfig {
         self.download = download
         self.prewarm = prewarm
         self.load = load
+        self.preserveExistingAudioSession = preserveExistingAudioSession
         self.seed = seed
     }
 

--- a/Sources/TTSKit/TTSKit.swift
+++ b/Sources/TTSKit/TTSKit.swift
@@ -999,6 +999,42 @@ open class TTSKit: @unchecked Sendable {
         playbackStrategy: PlaybackStrategy = .auto,
         callback: SpeechCallback = nil
     ) async throws -> SpeechResult {
+        try await play(
+            text: text,
+            voice: voice,
+            language: language,
+            options: options,
+            playbackStrategy: playbackStrategy,
+            preserveExistingAudioSession: false,
+            callback: callback
+        )
+    }
+
+    /// Generate speech and stream it through the audio output in real time.
+    ///
+    /// Generates speech and plays it back.
+    ///
+    /// - Parameters:
+    ///   - text: The text to synthesize.
+    ///   - voice: Voice/speaker identifier.
+    ///   - language: Language identifier.
+    ///   - options: Sampling and generation options.
+    ///   - playbackStrategy: Controls how audio is buffered before playback begins.
+    ///   - preserveExistingAudioSession: When `true` on iOS, playback reuses the
+    ///     host app's current audio session configuration instead of forcing
+    ///     `.playback`.
+    ///   - callback: Optional per-step callback.
+    /// - Returns: A `SpeechResult` with the complete audio and timing breakdown.
+    /// - Throws: `TTSError` on generation failure or task cancellation.
+    open func play(
+        text: String,
+        voice: String? = nil,
+        language: String? = nil,
+        options: GenerationOptions = GenerationOptions(),
+        playbackStrategy: PlaybackStrategy = .auto,
+        preserveExistingAudioSession: Bool = false,
+        callback: SpeechCallback = nil
+    ) async throws -> SpeechResult {
         var playOptions = options
 
         let audioOut = audioOutput
@@ -1016,7 +1052,9 @@ open class TTSKit: @unchecked Sendable {
                 text: text, voice: voice, language: language,
                 options: playOptions, callback: callback
             )
-            try audioOut.startPlayback()
+            try audioOut.startPlayback(
+                preserveExistingAudioSession: preserveExistingAudioSession
+            )
             audioOut.setBufferDuration(0)
             audioOut.enqueueAudioChunk(result.audio)
             await audioOut.stopPlayback(waitForCompletion: true)
@@ -1026,7 +1064,10 @@ open class TTSKit: @unchecked Sendable {
         // Streaming requires sequential generation to preserve chunk order.
         playOptions.concurrentWorkerCount = 1
 
-        try audioOut.startPlayback(deferEngineStart: true)
+        try audioOut.startPlayback(
+            deferEngineStart: true,
+            preserveExistingAudioSession: preserveExistingAudioSession
+        )
         switch playbackStrategy {
             case .stream: audioOut.setBufferDuration(0)
             case let .buffered(secs): audioOut.setBufferDuration(secs)
@@ -1128,6 +1169,7 @@ open class TTSKit: @unchecked Sendable {
         language: Qwen3Language = .english,
         options: GenerationOptions = GenerationOptions(),
         playbackStrategy: PlaybackStrategy = .auto,
+        preserveExistingAudioSession: Bool = false,
         callback: SpeechCallback = nil
     ) async throws -> SpeechResult {
         try await play(
@@ -1136,6 +1178,7 @@ open class TTSKit: @unchecked Sendable {
             language: language.rawValue,
             options: options,
             playbackStrategy: playbackStrategy,
+            preserveExistingAudioSession: preserveExistingAudioSession,
             callback: callback
         )
     }

--- a/Sources/TTSKit/TTSKit.swift
+++ b/Sources/TTSKit/TTSKit.swift
@@ -999,42 +999,6 @@ open class TTSKit: @unchecked Sendable {
         playbackStrategy: PlaybackStrategy = .auto,
         callback: SpeechCallback = nil
     ) async throws -> SpeechResult {
-        try await play(
-            text: text,
-            voice: voice,
-            language: language,
-            options: options,
-            playbackStrategy: playbackStrategy,
-            preserveExistingAudioSession: false,
-            callback: callback
-        )
-    }
-
-    /// Generate speech and stream it through the audio output in real time.
-    ///
-    /// Generates speech and plays it back.
-    ///
-    /// - Parameters:
-    ///   - text: The text to synthesize.
-    ///   - voice: Voice/speaker identifier.
-    ///   - language: Language identifier.
-    ///   - options: Sampling and generation options.
-    ///   - playbackStrategy: Controls how audio is buffered before playback begins.
-    ///   - preserveExistingAudioSession: When `true` on iOS, playback reuses the
-    ///     host app's current audio session configuration instead of forcing
-    ///     `.playback`.
-    ///   - callback: Optional per-step callback.
-    /// - Returns: A `SpeechResult` with the complete audio and timing breakdown.
-    /// - Throws: `TTSError` on generation failure or task cancellation.
-    open func play(
-        text: String,
-        voice: String? = nil,
-        language: String? = nil,
-        options: GenerationOptions = GenerationOptions(),
-        playbackStrategy: PlaybackStrategy = .auto,
-        preserveExistingAudioSession: Bool = false,
-        callback: SpeechCallback = nil
-    ) async throws -> SpeechResult {
         var playOptions = options
 
         let audioOut = audioOutput
@@ -1053,7 +1017,7 @@ open class TTSKit: @unchecked Sendable {
                 options: playOptions, callback: callback
             )
             try audioOut.startPlayback(
-                preserveExistingAudioSession: preserveExistingAudioSession
+                preserveExistingAudioSession: config.preserveExistingAudioSession
             )
             audioOut.setBufferDuration(0)
             audioOut.enqueueAudioChunk(result.audio)
@@ -1066,7 +1030,7 @@ open class TTSKit: @unchecked Sendable {
 
         try audioOut.startPlayback(
             deferEngineStart: true,
-            preserveExistingAudioSession: preserveExistingAudioSession
+            preserveExistingAudioSession: config.preserveExistingAudioSession
         )
         switch playbackStrategy {
             case .stream: audioOut.setBufferDuration(0)
@@ -1169,7 +1133,6 @@ open class TTSKit: @unchecked Sendable {
         language: Qwen3Language = .english,
         options: GenerationOptions = GenerationOptions(),
         playbackStrategy: PlaybackStrategy = .auto,
-        preserveExistingAudioSession: Bool = false,
         callback: SpeechCallback = nil
     ) async throws -> SpeechResult {
         try await play(
@@ -1178,7 +1141,6 @@ open class TTSKit: @unchecked Sendable {
             language: language.rawValue,
             options: options,
             playbackStrategy: playbackStrategy,
-            preserveExistingAudioSession: preserveExistingAudioSession,
             callback: callback
         )
     }

--- a/Sources/TTSKit/TTSKit.swift
+++ b/Sources/TTSKit/TTSKit.swift
@@ -1005,42 +1005,6 @@ open class TTSKit: @unchecked Sendable {
         playbackStrategy: PlaybackStrategy = .auto,
         callback: SpeechCallback = nil
     ) async throws -> SpeechResult {
-        try await play(
-            text: text,
-            voice: voice,
-            language: language,
-            options: options,
-            playbackStrategy: playbackStrategy,
-            preserveExistingAudioSession: false,
-            callback: callback
-        )
-    }
-
-    /// Generate speech and stream it through the audio output in real time.
-    ///
-    /// Generates speech and plays it back.
-    ///
-    /// - Parameters:
-    ///   - text: The text to synthesize.
-    ///   - voice: Voice/speaker identifier.
-    ///   - language: Language identifier.
-    ///   - options: Sampling and generation options.
-    ///   - playbackStrategy: Controls how audio is buffered before playback begins.
-    ///   - preserveExistingAudioSession: When `true` on iOS, playback reuses the
-    ///     host app's current audio session configuration instead of forcing
-    ///     `.playback`.
-    ///   - callback: Optional per-step callback.
-    /// - Returns: A `SpeechResult` with the complete audio and timing breakdown.
-    /// - Throws: `TTSError` on generation failure or task cancellation.
-    open func play(
-        text: String,
-        voice: String? = nil,
-        language: String? = nil,
-        options: GenerationOptions = GenerationOptions(),
-        playbackStrategy: PlaybackStrategy = .auto,
-        preserveExistingAudioSession: Bool = false,
-        callback: SpeechCallback = nil
-    ) async throws -> SpeechResult {
         var playOptions = options
 
         let audioOut = audioOutput
@@ -1059,7 +1023,7 @@ open class TTSKit: @unchecked Sendable {
                 options: playOptions, callback: callback
             )
             try audioOut.startPlayback(
-                preserveExistingAudioSession: preserveExistingAudioSession
+                preserveExistingAudioSession: config.preserveExistingAudioSession
             )
             audioOut.setBufferDuration(0)
             audioOut.enqueueAudioChunk(result.audio)
@@ -1072,7 +1036,7 @@ open class TTSKit: @unchecked Sendable {
 
         try audioOut.startPlayback(
             deferEngineStart: true,
-            preserveExistingAudioSession: preserveExistingAudioSession
+            preserveExistingAudioSession: config.preserveExistingAudioSession
         )
         switch playbackStrategy {
             case .stream: audioOut.setBufferDuration(0)
@@ -1175,7 +1139,6 @@ open class TTSKit: @unchecked Sendable {
         language: Qwen3Language = .english,
         options: GenerationOptions = GenerationOptions(),
         playbackStrategy: PlaybackStrategy = .auto,
-        preserveExistingAudioSession: Bool = false,
         callback: SpeechCallback = nil
     ) async throws -> SpeechResult {
         try await play(
@@ -1184,7 +1147,6 @@ open class TTSKit: @unchecked Sendable {
             language: language.rawValue,
             options: options,
             playbackStrategy: playbackStrategy,
-            preserveExistingAudioSession: preserveExistingAudioSession,
             callback: callback
         )
     }

--- a/Sources/TTSKit/TTSKit.swift
+++ b/Sources/TTSKit/TTSKit.swift
@@ -1005,6 +1005,42 @@ open class TTSKit: @unchecked Sendable {
         playbackStrategy: PlaybackStrategy = .auto,
         callback: SpeechCallback = nil
     ) async throws -> SpeechResult {
+        try await play(
+            text: text,
+            voice: voice,
+            language: language,
+            options: options,
+            playbackStrategy: playbackStrategy,
+            preserveExistingAudioSession: false,
+            callback: callback
+        )
+    }
+
+    /// Generate speech and stream it through the audio output in real time.
+    ///
+    /// Generates speech and plays it back.
+    ///
+    /// - Parameters:
+    ///   - text: The text to synthesize.
+    ///   - voice: Voice/speaker identifier.
+    ///   - language: Language identifier.
+    ///   - options: Sampling and generation options.
+    ///   - playbackStrategy: Controls how audio is buffered before playback begins.
+    ///   - preserveExistingAudioSession: When `true` on iOS, playback reuses the
+    ///     host app's current audio session configuration instead of forcing
+    ///     `.playback`.
+    ///   - callback: Optional per-step callback.
+    /// - Returns: A `SpeechResult` with the complete audio and timing breakdown.
+    /// - Throws: `TTSError` on generation failure or task cancellation.
+    open func play(
+        text: String,
+        voice: String? = nil,
+        language: String? = nil,
+        options: GenerationOptions = GenerationOptions(),
+        playbackStrategy: PlaybackStrategy = .auto,
+        preserveExistingAudioSession: Bool = false,
+        callback: SpeechCallback = nil
+    ) async throws -> SpeechResult {
         var playOptions = options
 
         let audioOut = audioOutput
@@ -1022,7 +1058,9 @@ open class TTSKit: @unchecked Sendable {
                 text: text, voice: voice, language: language,
                 options: playOptions, callback: callback
             )
-            try audioOut.startPlayback()
+            try audioOut.startPlayback(
+                preserveExistingAudioSession: preserveExistingAudioSession
+            )
             audioOut.setBufferDuration(0)
             audioOut.enqueueAudioChunk(result.audio)
             await audioOut.stopPlayback(waitForCompletion: true)
@@ -1032,7 +1070,10 @@ open class TTSKit: @unchecked Sendable {
         // Streaming requires sequential generation to preserve chunk order.
         playOptions.concurrentWorkerCount = 1
 
-        try audioOut.startPlayback(deferEngineStart: true)
+        try audioOut.startPlayback(
+            deferEngineStart: true,
+            preserveExistingAudioSession: preserveExistingAudioSession
+        )
         switch playbackStrategy {
             case .stream: audioOut.setBufferDuration(0)
             case let .buffered(secs): audioOut.setBufferDuration(secs)
@@ -1134,6 +1175,7 @@ open class TTSKit: @unchecked Sendable {
         language: Qwen3Language = .english,
         options: GenerationOptions = GenerationOptions(),
         playbackStrategy: PlaybackStrategy = .auto,
+        preserveExistingAudioSession: Bool = false,
         callback: SpeechCallback = nil
     ) async throws -> SpeechResult {
         try await play(
@@ -1142,6 +1184,7 @@ open class TTSKit: @unchecked Sendable {
             language: language.rawValue,
             options: options,
             playbackStrategy: playbackStrategy,
+            preserveExistingAudioSession: preserveExistingAudioSession,
             callback: callback
         )
     }

--- a/Sources/TTSKit/Utilities/AudioOutput.swift
+++ b/Sources/TTSKit/Utilities/AudioOutput.swift
@@ -479,12 +479,20 @@ public class AudioOutput: @unchecked Sendable {
     /// Resets all buffering, fade, and timing state. After calling this,
     /// configure the buffer threshold via `setBufferDuration(_:)`.
     ///
-    /// - Parameter deferEngineStart: When `true`, the audio engine is created and
-    ///   connected but not started. The engine will start automatically on the first
-    ///   `enqueueAudioChunk` call. This avoids the render thread contending with
-    ///   model predictions during the critical time-to-first-buffer path.
+    /// - Parameters:
+    ///   - deferEngineStart: When `true`, the audio engine is created and
+    ///     connected but not started. The engine will start automatically on the first
+    ///     `enqueueAudioChunk` call. This avoids the render thread contending with
+    ///     model predictions during the critical time-to-first-buffer path.
+    ///   - preserveExistingAudioSession: When `true` on iOS, reuses the caller's
+    ///     current `AVAudioSession` category/mode/options without modification.
+    ///     Routing, speaker-vs-receiver behavior, and engine compatibility are
+    ///     then fully determined by the host app's existing session setup.
     /// - Throws: `TTSError` if the audio engine fails to start.
-    public func startPlayback(deferEngineStart: Bool = false) throws {
+    public func startPlayback(
+        deferEngineStart: Bool = false,
+        preserveExistingAudioSession: Bool = false
+    ) throws {
         pendingFrames.removeAll()
         pendingDuration = 0
         bufferThresholdMet = false
@@ -496,12 +504,14 @@ public class AudioOutput: @unchecked Sendable {
         scheduledAudioDuration = 0
         engineStartDeferred = false
 
-        // On iOS, AVAudioEngine requires an active audio session with a playback
-        // category. Without this, engine.start() may silently fail or route to
-        // the wrong output (e.g., airpods instead of main speaker).
+        // On iOS, AVAudioEngine requires an active audio session configured for
+        // playback. Callers that need to fully preserve a host-managed session
+        // can opt out and accept responsibility for routing and compatibility.
         #if os(iOS)
         let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.playback, mode: .default, options: [])
+        if !preserveExistingAudioSession {
+            try session.setCategory(.playback, mode: .default, options: [])
+        }
         try session.setActive(true)
         #endif
 


### PR DESCRIPTION
Adds a `preserveExistingAudioSession` option to `TTSKitConfig` for iOS playback.

By default, behavior is unchanged and `TTSKit` still configures `AVAudioSession` for `.playback` when starting playback. When `preserveExistingAudioSession` is enabled, `TTSKit` only activates the existing session and leaves its category, mode, and options untouched.

## Why

Some apps already own an active `.playAndRecord` session when starting TTS playback. Attempting to switch that shared session to `.playback` can fail at runtime, so this opt-in allows host apps to keep their existing audio session configuration.

## Testing

- `swift build --target TTSKit`
- Manual review of the iOS playback startup path