### PR TITLE
Add playback callback to TTSKit play

### DIFF
--- a/Sources/TTSKit/TTSKit.swift
+++ b/Sources/TTSKit/TTSKit.swift
@@ -9,6 +9,11 @@ import os
 
 // MARK: - Callback Typealiases
 
+/// A closure invoked when audio samples are aligned with playback.
+///
+/// Use this for playback-reactive features such as metering or lip sync.
+public typealias PlaybackCallback = (@Sendable ([Float]) -> Void)?
+
 // MARK: - TTSKit
 
 /// Generic TTS orchestrator: text chunking, concurrent generation, crossfade, and audio playback.
@@ -1003,11 +1008,14 @@ open class TTSKit: @unchecked Sendable {
         language: String? = nil,
         options: GenerationOptions = GenerationOptions(),
         playbackStrategy: PlaybackStrategy = .auto,
-        callback: SpeechCallback = nil
+        callback: SpeechCallback = nil,
+        playbackCallback: PlaybackCallback = nil
     ) async throws -> SpeechResult {
         var playOptions = options
 
         let audioOut = audioOutput
+        audioOut.playbackCallback = playbackCallback
+        defer { audioOut.playbackCallback = nil }
         let maxTokens = playOptions.maxNewTokens
 
         // Pre-resolve audio format from the task so the playback closure doesn't
@@ -1066,6 +1074,25 @@ open class TTSKit: @unchecked Sendable {
 
         await audioOut.stopPlayback(waitForCompletion: true)
         return result
+    }
+
+    open func play(
+        text: String,
+        voice: String?,
+        language: String?,
+        options: GenerationOptions,
+        playbackStrategy: PlaybackStrategy,
+        callback: SpeechCallback
+    ) async throws -> SpeechResult {
+        try await play(
+            text: text,
+            voice: voice,
+            language: language,
+            options: options,
+            playbackStrategy: playbackStrategy,
+            callback: callback,
+            playbackCallback: nil
+        )
     }
 
     // MARK: - Qwen3-typed convenience API
@@ -1134,7 +1161,8 @@ open class TTSKit: @unchecked Sendable {
         language: Qwen3Language = .english,
         options: GenerationOptions = GenerationOptions(),
         playbackStrategy: PlaybackStrategy = .auto,
-        callback: SpeechCallback = nil
+        callback: SpeechCallback = nil,
+        playbackCallback: PlaybackCallback = nil
     ) async throws -> SpeechResult {
         try await play(
             text: text,
@@ -1142,7 +1170,27 @@ open class TTSKit: @unchecked Sendable {
             language: language.rawValue,
             options: options,
             playbackStrategy: playbackStrategy,
-            callback: callback
+            callback: callback,
+            playbackCallback: playbackCallback
+        )
+    }
+
+    open func play(
+        text: String,
+        speaker: Qwen3Speaker,
+        language: Qwen3Language = .english,
+        options: GenerationOptions = GenerationOptions(),
+        playbackStrategy: PlaybackStrategy = .auto,
+        callback: SpeechCallback = nil
+    ) async throws -> SpeechResult {
+        try await play(
+            text: text,
+            speaker: speaker,
+            language: language,
+            options: options,
+            playbackStrategy: playbackStrategy,
+            callback: callback,
+            playbackCallback: nil
         )
     }
 }

--- a/Sources/TTSKit/Utilities/AudioOutput.swift
+++ b/Sources/TTSKit/Utilities/AudioOutput.swift
@@ -39,6 +39,8 @@ public class AudioOutput: @unchecked Sendable {
     private var audioEngine: AVAudioEngine?
     private var playerNode: AVAudioPlayerNode?
     private var engineStartDeferred: Bool = false
+    var playbackCallback: PlaybackCallback = nil
+    public private(set) var isOutputSuppressed = false
 
     /// Pre-buffer threshold in seconds. `nil` means not yet configured - frames
     /// accumulate in `pendingFrames` until `setBufferDuration` is called.
@@ -110,6 +112,15 @@ public class AudioOutput: @unchecked Sendable {
             preconditionFailure("AVAudioFormat init failed for PCM Float32 \(newRate)Hz mono - this is an invariant violation")
         }
         audioFormat = format
+    }
+
+    /// Suppress or restore audible playback output.
+    ///
+    /// This updates the active engine immediately when playback is in progress and
+    /// also becomes the default for the next `startPlayback()` call.
+    public func setOutputSuppressed(_ isSuppressed: Bool) {
+        isOutputSuppressed = isSuppressed
+        audioEngine?.mainMixerNode.outputVolume = isSuppressed ? 0 : 1
     }
 
     /// Current playback position in seconds, based on the audio engine's render timeline.
@@ -521,6 +532,7 @@ public class AudioOutput: @unchecked Sendable {
 
         self.audioEngine = engine
         self.playerNode = player
+        setOutputSuppressed(isOutputSuppressed)
     }
 
     /// Enqueue a chunk of audio samples for playback.
@@ -672,7 +684,14 @@ public class AudioOutput: @unchecked Sendable {
         expectedPlaybackEnd = max(expectedPlaybackEnd, now) + bufferSeconds
         scheduledAudioDuration += bufferSeconds
 
-        player.scheduleBuffer(buffer)
+        if let playbackCallback = self.playbackCallback {
+            let playedSamples = samples
+            player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { _ in
+                playbackCallback(playedSamples)
+            }
+        } else {
+            player.scheduleBuffer(buffer)
+        }
     }
 
     /// Stop playback and tear down the audio engine.

--- a/Tests/TTSKitTests/TTSKitIntegrationTests.swift
+++ b/Tests/TTSKitTests/TTSKitIntegrationTests.swift
@@ -264,6 +264,28 @@ final class TTSKitIntegrationTests: XCTestCase {
         XCTAssertEqual(result.sampleRate, 24000)
     }
 
+    /// Playback callback should fire with non-empty samples during real-time playback.
+    func testPlaybackCallbackReceivesSamples() async throws {
+        let tts = try await makeCachedTTS(seed: 42)
+        tts.audioOutput.setOutputSuppressed(true)
+        let callbackExpectation = expectation(description: "Playback callback fired")
+        callbackExpectation.assertForOverFulfill = false
+
+        _ = try await tts.play(
+            text: "Playback callback smoke test.",
+            speaker: .ryan,
+            language: .english,
+            options: GenerationOptions(temperature: 0.0, topK: 0, maxNewTokens: 80),
+            playbackStrategy: .generateFirst,
+            playbackCallback: { samples in
+                guard samples.isEmpty == false else { return }
+                callbackExpectation.fulfill()
+            }
+        )
+
+        await fulfillment(of: [callbackExpectation], timeout: 5.0)
+    }
+
     // MARK: - Performance
 
     /// Verify timings are populated and the generation loop completed within a reasonable ceiling.

--- a/Tests/TTSKitTests/TTSKitUnitTests.swift
+++ b/Tests/TTSKitTests/TTSKitUnitTests.swift
@@ -51,6 +51,15 @@ final class TTSKitUnitTests: XCTestCase {
         XCTAssertNotNil(opts.concurrentWorkerCount)
     }
 
+    func testOutputSuppressionToggleState() {
+        let output = AudioOutput()
+        XCTAssertFalse(output.isOutputSuppressed, "Suppression should be disabled by default")
+        output.setOutputSuppressed(true)
+        XCTAssertTrue(output.isOutputSuppressed, "Suppression should be enabled after setting true")
+        output.setOutputSuppressed(false)
+        XCTAssertFalse(output.isOutputSuppressed, "Suppression should be disabled after setting false")
+    }
+
     func testDownloadPatterns() {
         let config = TTSKitConfig()
         let patterns = config.downloadPatterns


### PR DESCRIPTION
## Summary

This PR adds a playback-synchronized audio callback for TTS playback.

`TTSKit` already exposes generated audio through `SpeechCallback`, but that callback is tied to generation time, not actual playback time. For use cases like lip sync, waveform visualization, and other playback-reactive UI, consumers need audio samples that correspond to what is actually being scheduled/played by `AVAudioPlayerNode`.

## Why this is needed

Generation-time callbacks can drift from audible playback because playback depends on player scheduling, buffering, output timing, and suppression/test paths. For lip sync in particular, reacting to generated samples is not enough: the animation should follow what the user actually hears.

This PR introduces a callback at the playback layer so consumers can observe the audio that is scheduled for playback, rather than only the audio that was produced by the model.

## Notes from the previous PR discussion

This is a continuation/replacement of #445, which was accidentally closed after the source branch was deleted/restored.

A question came up there about whether this callback is intended to attach to what is actually scheduled in `playerNode`, so consumers receive samples as they are played/scheduled rather than as they are generated.

Yes — that is the intended distinction.

`SpeechCallback` remains useful for generation-time access to audio, but the new callback is meant for playback-synchronized consumers such as lip sync and visualizers.

Another question was whether output suppression effectively turns this into a custom playback backend API.

That is not the goal of this PR. `setOutputSuppressed(true)` is primarily useful for tests and non-audible playback paths. It makes the playback pipeline testable without producing sound, but this PR is not trying to promote suppression as a first-class replacement for the built-in audio playback system.

## Intended use cases

- Playback-synchronized lip sync
- Waveform / level visualization tied to actual playback
- Tests that verify playback callback behavior without audible output

## Non-goals

- Replacing `SpeechCallback`
- Providing a full custom audio backend API
- Making output suppression the primary way to consume generated TTS audio

## Related

Replaces / continues #445.